### PR TITLE
Fix/holding period return

### DIFF
--- a/src/components/Contexts/Currency/Currency.tsx
+++ b/src/components/Contexts/Currency/Currency.tsx
@@ -1,7 +1,6 @@
-import React, { useState, createContext, useEffect, useMemo } from 'react';
+import React, { useState, createContext } from 'react';
 import { useRates } from '../Rates/Rates';
 import { Rates, RatesItem } from '~/utils/fetchRates';
-import BigNumber from 'bignumber.js';
 
 export const currencyList = [
   { symbol: 'USD', name: 'US Dollar' },

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
@@ -85,7 +85,7 @@ export function monthlyReturnsFromTimeline(
 ): MonthlyReturnData {
   let maxDigits = 0;
 
-  const activeMonthReturns: DisplayData[] = monthlyReturnData.map(
+  const activeMonthReturns: DisplayData[] = monthlyReturnData?.map(
     (item: MonthendTimelineItem, index: number, arr: MonthendTimelineItem[]) => {
       const prevIndex = index === 0 ? 0 : index - 1;
       // if the prior month had no shares and this month has shares, this month's return is based on an opening share price of 1
@@ -93,21 +93,21 @@ export function monthlyReturnsFromTimeline(
       // if the prior month had shares and this month has no shares, this month's return is NA
       // if the prior month had share and this month has shares this month's return is as per
 
-      const previousFxRate = new BigNumber(getRate(arr[prevIndex].rates, currency));
+      // const previousFxRate = new BigNumber(getRate(arr[prevIndex].rates, currency));
 
-      // if prior month had no shares, set price === 1, else take the actual share price
-      const previousSharePrice = new BigNumber(arr[prevIndex].shares == 0 ? 1 : arr[prevIndex].calculations.price);
+      // // if prior month had no shares, set price === 1, else take the actual share price
+      // const previousSharePrice = new BigNumber(arr[prevIndex].shares == 0 ? 1 : arr[prevIndex].calculations.price);
 
-      const previous = previousSharePrice.dividedBy(previousFxRate);
+      // const previous = previousSharePrice.dividedBy(previousFxRate);
 
-      const currentFxRate = new BigNumber(getRate(item.rates, currency));
-      const current = new BigNumber(item.calculations.price).dividedBy(currentFxRate);
+      // const currentFxRate = new BigNumber(getRate(item.rates, currency));
+      // const current = new BigNumber(item.calculations.price).dividedBy(currentFxRate);
 
-      const rtrn = calculateReturn(current, previous);
+      const rtrn = new BigNumber(item.returns[currency]);
 
-      if (rtrn.toPrecision(2).length > maxDigits) {
-        maxDigits = rtrn.toPrecision(2).length;
-      }
+      // if (rtrn.toPrecision(2).length > maxDigits) {
+      //   maxDigits = rtrn.toPrecision(2).length;
+      // }
 
       const rawDate = new Date(item.timestamp * 1000);
       const date = addMinutes(rawDate, rawDate.getTimezoneOffset());

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
@@ -87,9 +87,14 @@ export function monthlyReturnsFromTimeline(
   const activeMonthReturns: DisplayData[] = monthlyReturnData.map(
     (item: MonthendTimelineItem, index: number, arr: MonthendTimelineItem[]) => {
       const prevIndex = index === 0 ? 0 : index - 1;
+      // if the prior month had no shares and this month has shares, this month's return is based on an opening share price of 1
+      // if the prior month had no shares and this month has no shares, this month's return is NA
+      // if the prior month had shares and this month has no shares, this month's return is NA
+      // if the prior month had share and this month has shares this month's return is as per
 
       const previousFxRate = new BigNumber(getRate(arr[prevIndex].rates, currency));
-      const previous = new BigNumber(arr[prevIndex].calculations.price).dividedBy(previousFxRate);
+      const previousSharePrice = new BigNumber(arr[prevIndex].shares == 0 ? 1 : arr[prevIndex].calculations.price);
+      const previous = previousSharePrice.dividedBy(previousFxRate);
 
       const currentFxRate = new BigNumber(getRate(item.rates, currency));
       const current = new BigNumber(item.calculations.price).dividedBy(currentFxRate);
@@ -102,9 +107,9 @@ export function monthlyReturnsFromTimeline(
 
       const rawDate = new Date(item.timestamp * 1000);
       const date = addMinutes(rawDate, rawDate.getTimezoneOffset());
-
+      //
       return {
-        return: arr[prevIndex].calculations.price > 0 && item.calculations.gav > 0 ? rtrn : new BigNumber(NaN),
+        return: item.shares > 0 && arr[prevIndex].shares >= 0 ? rtrn : new BigNumber(NaN),
         date,
       };
     }

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
@@ -11,7 +11,6 @@ export interface DisplayData {
 }
 
 export interface MonthlyReturnData {
-  maxDigits: number;
   data: DisplayData[];
 }
 
@@ -83,40 +82,15 @@ export function monthlyReturnsFromTimeline(
   monthsBeforeFund?: number,
   monthsRemaining?: number
 ): MonthlyReturnData {
-  let maxDigits = 0;
-
   const activeMonthReturns: DisplayData[] = monthlyReturnData.map(
     (item: MonthendTimelineItem, index: number, arr: MonthendTimelineItem[]) => {
-      const prevIndex = index === 0 ? 0 : index - 1;
-      // if the prior month had no shares and this month has shares, this month's return is based on an opening share price of 1
-      // if the prior month had no shares and this month has no shares, this month's return is NA
-      // if the prior month had shares and this month has no shares, this month's return is NA
-      // if the prior month had share and this month has shares this month's return is as per
-
-      // const previousFxRate = new BigNumber(getRate(arr[prevIndex].rates, currency));
-
-      // // if prior month had no shares, set price === 1, else take the actual share price
-      // const previousSharePrice = new BigNumber(arr[prevIndex].shares == 0 ? 1 : arr[prevIndex].calculations.price);
-
-      // const previous = previousSharePrice.dividedBy(previousFxRate);
-
-      // const currentFxRate = new BigNumber(getRate(item.rates, currency));
-      // const current = new BigNumber(item.calculations.price).dividedBy(currentFxRate);
-
       const rtrn = new BigNumber(item.returns[currency]);
-
-      // if (rtrn.toPrecision(2).length > maxDigits) {
-      //   maxDigits = rtrn.toPrecision(2).length;
-      // }
 
       const rawDate = new Date(item.timestamp * 1000);
       const date = addMinutes(rawDate, rawDate.getTimezoneOffset());
-      //
+
       return {
-        // in the case where this month has shares, the prrior month either did not have shares, in which case we've set
-        // the price to 1, or it did have shares in which case we've taken the actual price. If this month
-        // doesn't have shares we return NaN
-        return: item.shares > 0 ? rtrn : new BigNumber(NaN),
+        return: rtrn,
         date,
       };
     }
@@ -155,5 +129,5 @@ export function monthlyReturnsFromTimeline(
       ? inactiveMonthReturns.concat(activeMonthReturns).concat(monthsRemainingInYear)
       : activeMonthReturns;
 
-  return { maxDigits: maxDigits, data: aggregatedMonthlyReturns };
+  return { data: aggregatedMonthlyReturns };
 }

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
@@ -85,7 +85,7 @@ export function monthlyReturnsFromTimeline(
 ): MonthlyReturnData {
   let maxDigits = 0;
 
-  const activeMonthReturns: DisplayData[] = monthlyReturnData?.map(
+  const activeMonthReturns: DisplayData[] = monthlyReturnData.map(
     (item: MonthendTimelineItem, index: number, arr: MonthendTimelineItem[]) => {
       const prevIndex = index === 0 ? 0 : index - 1;
       // if the prior month had no shares and this month has shares, this month's return is based on an opening share price of 1

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
@@ -46,14 +46,15 @@ export function calculateHoldingPeriodReturns(
   }
 
   const periodStart = relevantPriceData[0];
-  const periodStartPrice = periodStart.calculations.price === 0 ? 1 : periodStart.calculations.price;
   const periodEnd = relevantPriceData[relevantPriceData.length - 1];
 
   return calculateReturn(
     new BigNumber(periodEnd.calculations.gav > 0 ? periodEnd.calculations.price : NaN).dividedBy(
       getRate(periodEnd.rates, currency)
     ),
-    new BigNumber(periodStartPrice).dividedBy(getRate(periodStart.rates, currency))
+    new BigNumber(periodStart.calculations.price === 0 ? 1 : periodStart.calculations.price).dividedBy(
+      getRate(periodStart.rates, currency)
+    )
   );
 }
 

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMonthlyReturnTable.tsx
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMonthlyReturnTable.tsx
@@ -68,9 +68,7 @@ export const FundMonthlyReturnTable: React.FC<MonthlyReturnTableProps> = ({ addr
     if (!monthlyData || !fund) {
       return undefined;
     }
-    // if (fund.creationTime && differenceInCalendarDays(today, fund.creationTime) < 7) {
-    //   return undefined;
-    // }
+
     return monthlyReturnsFromTimeline(
       monthlyData.data ?? [{}],
       currency.currency,
@@ -87,17 +85,6 @@ export const FundMonthlyReturnTable: React.FC<MonthlyReturnTableProps> = ({ addr
       return format(addMonths(january, index), 'MMM');
     });
   }, []);
-
-  // if (fund.creationTime && differenceInCalendarDays(today, fund.creationTime) < 7) {
-  //   return (
-  //     <Block>
-  //       <SectionTitle>Monthly Returns</SectionTitle>
-  //       <NotificationBar kind="neutral">
-  //         <NotificationContent>Statistics are not available for funds younger than one week.</NotificationContent>
-  //       </NotificationBar>
-  //     </Block>
-  //   );
-  // }
 
   if (!tableData) {
     return (

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundSharePriceMetrics.tsx
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundSharePriceMetrics.tsx
@@ -49,7 +49,7 @@ export const FundSharePriceMetrics: React.FC<FundSharePriceMetricsProps> = (prop
   const { data: monthlyData, error: monthlyError, isFetching: monthlyFetching } = useFetchFundPricesByMonthEnd(
     fund.address!
   );
-
+  console.log(monthlyData?.data);
   const monthlyReturns = React.useMemo(() => {
     return monthlyData?.data && monthlyReturnsFromTimeline(monthlyData.data, currency.currency);
   }, [monthlyData?.data, currency.currency]);

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundSharePriceMetrics.tsx
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundSharePriceMetrics.tsx
@@ -49,7 +49,7 @@ export const FundSharePriceMetrics: React.FC<FundSharePriceMetricsProps> = (prop
   const { data: monthlyData, error: monthlyError, isFetching: monthlyFetching } = useFetchFundPricesByMonthEnd(
     fund.address!
   );
-  console.log(monthlyData?.data);
+
   const monthlyReturns = React.useMemo(() => {
     return monthlyData?.data && monthlyReturnsFromTimeline(monthlyData.data, currency.currency);
   }, [monthlyData?.data, currency.currency]);

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundSharePriceMetrics.tsx
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundSharePriceMetrics.tsx
@@ -5,7 +5,7 @@ import { FormattedNumber } from '~/components/Common/FormattedNumber/FormattedNu
 import { useFund } from '~/hooks/useFund';
 import { useFetchFundPricesByMonthEnd } from '~/hooks/metricsService/useFetchFundPricesByMonthEnd';
 import { useFetchFundPricesByRange, RangeTimelineItem } from '~/hooks/metricsService/useFetchFundPricesByRange';
-import { monthlyReturnsFromTimeline, DisplayData, calculateHoldingPeriodReturns } from './FundMetricsUtilFunctions';
+import { monthlyReturnsFromTimeline, DisplayData } from './FundMetricsUtilFunctions';
 import { DictionaryEntry, DictionaryLabel, DictionaryData } from '~/storybook/Dictionary/Dictionary';
 import { SectionTitle } from '~/storybook/Title/Title.styles';
 import { NotificationBar, NotificationContent } from '~/storybook/NotificationBar/NotificationBar';
@@ -61,17 +61,20 @@ export const FundSharePriceMetrics: React.FC<FundSharePriceMetricsProps> = (prop
   const lastQuarterendDate: number = (Date.UTC(utcYear, findLastQuarter(utcMonth)) - dayInMilliseconds) / 1000;
   const lastYearendDate: number = (Date.UTC(utcYear, 0) - dayInMilliseconds) / 1000;
 
-  const mtdReturn = React.useMemo(() => {
-    return calculateHoldingPeriodReturns(monthlyData?.data, lastMonthendDate, currency.currency);
-  }, [monthlyData, currency.currency]);
+  const mtdReturn = React.useMemo(
+    () => monthlyData?.data[monthlyData.data.length - 1].holdingPeriodReturns.monthToDate[currency.currency],
+    [monthlyData, currency.currency]
+  );
 
-  const qtdReturn = React.useMemo(() => {
-    return calculateHoldingPeriodReturns(monthlyData?.data, lastQuarterendDate, currency.currency);
-  }, [monthlyData, currency.currency]);
+  const qtdReturn = React.useMemo(
+    () => monthlyData?.data[monthlyData.data.length - 1].holdingPeriodReturns.quarterToDate[currency.currency],
+    [monthlyData, currency.currency]
+  );
 
-  const ytdReturn = React.useMemo(() => {
-    return calculateHoldingPeriodReturns(monthlyData?.data, lastYearendDate, currency.currency);
-  }, [monthlyData, currency.currency]);
+  const ytdReturn = React.useMemo(
+    () => monthlyData?.data[monthlyData.data.length - 1].holdingPeriodReturns.yearToDate[currency.currency],
+    [monthlyData, currency.currency]
+  );
 
   const filteredReturns = monthlyReturns?.data.filter((item) => !item.return.isNaN()) || [];
 

--- a/src/hooks/metricsService/useFetchFundPricesByMonthEnd.ts
+++ b/src/hooks/metricsService/useFetchFundPricesByMonthEnd.ts
@@ -8,14 +8,20 @@ export interface MonthendTimelineItem {
   holdings: {
     [symbol: string]: number;
   };
-  references?: {
-    [key: string]: number;
-  };
   shares: number;
   calculations: {
     price: number;
     gav: number;
     nav: number;
+  };
+  purchase: boolean;
+  redemption: boolean;
+  monthEnd: boolean;
+  returns: {
+    ETH: number;
+    BTC: number;
+    USD: number;
+    date: number;
   };
 }
 

--- a/src/hooks/metricsService/useFetchFundPricesByMonthEnd.ts
+++ b/src/hooks/metricsService/useFetchFundPricesByMonthEnd.ts
@@ -18,9 +18,7 @@ export interface MonthendTimelineItem {
   redemption: boolean;
   monthEnd: boolean;
   returns: {
-    ETH: number;
-    BTC: number;
-    USD: number;
+    [symbol: string]: number;
     date: number;
   };
 }

--- a/src/hooks/metricsService/useFetchFundPricesByMonthEnd.ts
+++ b/src/hooks/metricsService/useFetchFundPricesByMonthEnd.ts
@@ -1,5 +1,23 @@
 import { useQuery } from 'react-query';
 
+interface HoldingPeriodReturns {
+  monthToDate: {
+    ETH: number | null;
+    BTC: number | null;
+    USD: number | null;
+  };
+  quarterToDate: {
+    ETH: number | null;
+    BTC: number | null;
+    USD: number | null;
+  };
+  yearToDate: {
+    ETH: number | null;
+    BTC: number | null;
+    USD: number | null;
+  };
+}
+
 export interface MonthendTimelineItem {
   timestamp: number;
   rates: {
@@ -17,10 +35,11 @@ export interface MonthendTimelineItem {
   purchase: boolean;
   redemption: boolean;
   monthEnd: boolean;
-  returns: {
+  monthlyReturns: {
     [symbol: string]: number;
     date: number;
   };
+  holdingPeriodReturns: HoldingPeriodReturns;
 }
 
 async function fetchFundPricesByMonthEnd(key: string, address: string) {


### PR DESCRIPTION
This PR is an extension of #616 and refactors the front end to accommodate the new format of the objects returned from the metrics servce `monthEnd` endpoint. It does this largely by removing the calculations and just interpreting the values returned from the endpoint. 