### PR TITLE
Fix/monthly returns

### DIFF
--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
@@ -33,6 +33,7 @@ export function monthlyReturnsFromTimeline(
   monthsBeforeFund?: number,
   monthsRemaining?: number
 ): MonthlyReturnData {
+  console.log(monthlyReturnData);
   const activeMonthReturns: DisplayData[] = monthlyReturnData.map((item: MonthendTimelineItem) => {
     const rtrn = new BigNumber(item.monthlyReturns?.[currency]);
 
@@ -73,10 +74,20 @@ export function monthlyReturnsFromTimeline(
         })
       : [];
 
+  console.log(
+    'months this year before fund: ',
+    inactiveMonthReturns,
+    'months this year after fund: ',
+    monthsRemainingInYear,
+    'fund returns',
+    activeMonthReturns
+  );
   const aggregatedMonthlyReturns =
     inactiveMonthReturns && monthsRemainingInYear
       ? inactiveMonthReturns.concat(activeMonthReturns).concat(monthsRemainingInYear)
       : activeMonthReturns;
+
+  console.log(aggregatedMonthlyReturns);
 
   return { data: aggregatedMonthlyReturns };
 }

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMetricsUtilFunctions.ts
@@ -33,7 +33,6 @@ export function monthlyReturnsFromTimeline(
   monthsBeforeFund?: number,
   monthsRemaining?: number
 ): MonthlyReturnData {
-  console.log(monthlyReturnData);
   const activeMonthReturns: DisplayData[] = monthlyReturnData.map((item: MonthendTimelineItem) => {
     const rtrn = new BigNumber(item.monthlyReturns?.[currency]);
 
@@ -74,20 +73,10 @@ export function monthlyReturnsFromTimeline(
         })
       : [];
 
-  console.log(
-    'months this year before fund: ',
-    inactiveMonthReturns,
-    'months this year after fund: ',
-    monthsRemainingInYear,
-    'fund returns',
-    activeMonthReturns
-  );
   const aggregatedMonthlyReturns =
     inactiveMonthReturns && monthsRemainingInYear
       ? inactiveMonthReturns.concat(activeMonthReturns).concat(monthsRemainingInYear)
       : activeMonthReturns;
-
-  console.log(aggregatedMonthlyReturns);
 
   return { data: aggregatedMonthlyReturns };
 }

--- a/src/components/Routes/Fund/FundPerformanceMetrics/FundMonthlyReturnTable.tsx
+++ b/src/components/Routes/Fund/FundPerformanceMetrics/FundMonthlyReturnTable.tsx
@@ -54,7 +54,7 @@ export const FundMonthlyReturnTable: React.FC<MonthlyReturnTableProps> = ({ addr
 
   const { data: monthlyData, error: monthlyError } = useFetchFundPricesByMonthEnd(address);
 
-  const firstDate = new Date(fundInception.getTime());
+  const firstDate = monthlyData && new Date(monthlyData.data[0].timestamp * 1000);
   const lastDate = new Date(monthlyData?.data?.[monthlyData?.data?.length - 1]?.timestamp * 1000);
 
   const monthsBeforeFund = differenceInCalendarMonths(firstDate, startOfYear(new Date(activeYears[0], 1, 1)));


### PR DESCRIPTION
Addresses an issue where a fund was created and the manager waited a couple of months and then invested. The metrics service returns information only on months where the fund is active (holds assets), and the function to aggregate the empty months on either side of the metrics service data (for display purposes) built those empty months based on the difference between the fund's inception date and the beginning of the year. This fix generates the empty months based on the difference between the first date returned by the metrics service and the beginning of the year.

With this fix Rhino fund is unchanged from the currently deployed.